### PR TITLE
Failing test case for jpg labeled as image/gif

### DIFF
--- a/test/createRightImagePipeline.js
+++ b/test/createRightImagePipeline.js
@@ -127,6 +127,28 @@ describe("createRightImagePipeline", () => {
         );
     });
 
+
+    it("should error when passing in a jpg labeled as being a gif", () => {
+        const imageFileStream = fs.createReadStream(
+            path.join(TEST_DATA_PATH, "test.jpg")
+        );
+
+        return expect(
+            function(cb) {
+                createRightImagePipeline(
+                    {
+                        contentType: "image/gif",
+                        inputStream: imageFileStream,
+                        imageOptions: { rotate: 0 }
+                    },
+                    cb
+                );
+            },
+            "to call the callback with error",
+            "foo"
+        );
+    });
+
     it("should error when an operation argument could not be mapped", () => {
         const imageFileStream = fs.createReadStream(
             path.join(TEST_DATA_PATH, "tiny.png")


### PR DESCRIPTION
I found this from a production issue. A customer has a file that is called `foo.gif` but is really a JPEG. When passing it through rightimage it breaks pretty badly.

In my production code, there might be other issues, as the result is a hanging request. I do get an error event back out of outputStream, that I eventually found was not being passed to next.

However, before I got as far, I added this test to rightimage. The results vary a little:

1. If you `it.skip` the added test case all tests pass.
2. If you `it.only` the added test, it fails.
3. If you run the entire test suite, more than just the added test fails.

It seems that there's some bug in the errorhandling somewhere - it might very well be further down the stack, but this is as far as I could go. Maybe it's a custom assertion?

I don't know how, or if we can at all, identify what this image is, but we should at least error out cleanly :-)