### PR TITLE
Accept  'maxInputPixels' in createRightImagePipeline

### DIFF
--- a/lib/createRightImagePipeline.js
+++ b/lib/createRightImagePipeline.js
@@ -12,7 +12,7 @@ const {
 function arrangeImageTransformsAndApply(
     contentType,
     imageOptions,
-    maxInputPixels = null
+    maxInputPixels
 ) {
     const [, type] = contentType.split("/");
 
@@ -48,9 +48,8 @@ function arrangeImageTransformsAndApply(
 
         operations.push({ name, args });
     }
-    const options = maxInputPixels ? { type, maxInputPixels } : { type };
     const expressProcessImageResult = converter.createPipeline(
-        options,
+        { type, maxInputPixels },
         operations
     );
 

--- a/lib/createRightImagePipeline.js
+++ b/lib/createRightImagePipeline.js
@@ -9,7 +9,11 @@ const {
     supportedOutputTypes
 } = require("./converter");
 
-function arrangeImageTransformsAndApply(contentType, imageOptions) {
+function arrangeImageTransformsAndApply(
+    contentType,
+    imageOptions,
+    maxInputPixels = null
+) {
     const [, type] = contentType.split("/");
 
     imageOptions = { ...imageOptions };
@@ -44,9 +48,9 @@ function arrangeImageTransformsAndApply(contentType, imageOptions) {
 
         operations.push({ name, args });
     }
-
+    const options = maxInputPixels ? { type, maxInputPixels } : { type };
     const expressProcessImageResult = converter.createPipeline(
-        { type },
+        options,
         operations
     );
 
@@ -71,6 +75,7 @@ function makeOutputContentType(contentType, imageOptions) {
 function createRightImagePipeline(
     {
         contentType,
+        maxInputPixels,
         inputStream,
         imageOptions = null,
         postProcessImageOptions,
@@ -161,7 +166,8 @@ function createRightImagePipeline(
         try {
             arranged = arrangeImageTransformsAndApply(
                 contentType,
-                imageOptions
+                imageOptions,
+                maxInputPixels
             );
         } catch (err) {
             return callback(err);


### PR DESCRIPTION
The "impro" module takes an option called maxInputPixels .Unfortunately, it doesn't seem like we are able to get it to be passed into rightimage.