### PR TITLE
Accept 'maxInputPixels' in createRightImagePipeline

### DIFF
--- a/lib/createRightImagePipeline.js
+++ b/lib/createRightImagePipeline.js
@@ -9,7 +9,7 @@ const {
     supportedOutputTypes
 } = require("./converter");
 
-function arrangeImageTransformsAndApply(contentType, imageOptions) {
+function arrangeImageTransformsAndApply(contentType, imageOptions, maxInputPixels) {
     const [, type] = contentType.split("/");
 
     imageOptions = { ...imageOptions };
@@ -46,7 +46,7 @@ function arrangeImageTransformsAndApply(contentType, imageOptions) {
     }
 
     const expressProcessImageResult = converter.createPipeline(
-        { type },
+        { type, maxInputPixels },
         operations
     );
 
@@ -72,6 +72,7 @@ function createRightImagePipeline(
     {
         contentType,
         inputStream,
+        maxInputPixels,
         imageOptions = null,
         postProcessImageOptions,
         ...options
@@ -110,7 +111,8 @@ function createRightImagePipeline(
 
         const outputContentType = makeOutputContentType(
             contentType,
-            imageOptions
+            imageOptions,
+            maxInputPixels
         );
         const [, type] = outputContentType.split("/");
         if (!supportedOutputTypes.has(type)) {


### PR DESCRIPTION
The "impro" module takes an option called maxInputPixels .Unfortunately, it doesn't seem like we are able to get it to be passed into rightimage.